### PR TITLE
fix: make build-time code generation work on Windows

### DIFF
--- a/src/toolguard/buildtime/gen_py/tool_guard_generator.py
+++ b/src/toolguard/buildtime/gen_py/tool_guard_generator.py
@@ -128,7 +128,10 @@ class ToolGuardGenerator:
                 return None, guard
             except Exception as ex:
                 logger.exception(ex)
-                logger.warning("guard generation failed. returning initial guard")
+                logger.error(
+                    f"Guard generation failed for item '{item.name}'; shipping the "
+                    f"initial scaffold (stub) guard, which performs no checks."
+                )
                 return None, init_guard
 
         # Tests generated, now generate guards
@@ -142,8 +145,9 @@ class ToolGuardGenerator:
             return guard_tests, guard
         except Exception as ex:
             logger.exception(ex)
-            logger.warning(
-                f"guard generation failed. returning initial guard: {str(ex)}"
+            logger.error(
+                f"Guard generation failed for item '{item.name}'; shipping the "
+                f"initial scaffold (stub) guard, which performs no checks: {str(ex)}"
             )
             return None, init_guard
 

--- a/src/toolguard/buildtime/gen_spec/utils.py
+++ b/src/toolguard/buildtime/gen_spec/utils.py
@@ -20,7 +20,9 @@ CRITICAL OUTPUT RULES:
 @cache
 def read_prompt_file(filename: str, return_json: bool = True) -> str:
     with open(
-        os.path.join(os.path.dirname(__file__), "prompts", filename + ".txt"), "r"
+        os.path.join(os.path.dirname(__file__), "prompts", filename + ".txt"),
+        "r",
+        encoding="utf-8",
     ) as f:
         prompt = f.read()
 

--- a/src/toolguard/buildtime/utils/py.py
+++ b/src/toolguard/buildtime/utils/py.py
@@ -56,7 +56,7 @@ def to_py_module_name(txt: str) -> str:
 
 
 def top_level_types(path: str | Path) -> Set[str]:
-    nodes = ast.parse(Path(path).read_text()).body
+    nodes = ast.parse(Path(path).read_text(encoding="utf-8")).body
     res = set()
     for node in nodes:
         if isinstance(node, ast.ClassDef):

--- a/src/toolguard/buildtime/utils/pyright.py
+++ b/src/toolguard/buildtime/utils/pyright.py
@@ -1,5 +1,6 @@
 import asyncio
 import json
+import shutil
 import sys
 from pathlib import Path
 from typing import List, Optional
@@ -10,6 +11,24 @@ from toolguard.runtime.data_types import FileTwin
 
 ERROR = "error"
 WARNING = "warning"
+
+
+def _resolve_pyright() -> str:
+    """Locate the pyright console script.
+
+    The ``pyright`` console script is installed next to the interpreter (the
+    venv ``Scripts``/``bin`` directory). Prefer that absolute path so it is found
+    even when the script directory is not on ``PATH`` — a common situation on
+    Windows, where the bare name otherwise raises
+    ``FileNotFoundError: [WinError 2]``. Fall back to a ``PATH`` lookup and
+    finally to the bare name.
+    """
+    bindir = Path(sys.executable).parent
+    for name in ("pyright", "pyright.exe", "pyright.cmd", "pyright.bat"):
+        candidate = bindir / name
+        if candidate.exists():
+            return str(candidate)
+    return shutil.which("pyright") or "pyright"
 
 
 class Position(BaseModel):
@@ -88,7 +107,7 @@ async def run(folder: Path, py_file: Path) -> DiagnosticsReport:
     py_path = sys.executable
 
     process = await asyncio.create_subprocess_exec(
-        "pyright",
+        _resolve_pyright(),
         "--pythonpath",
         py_path,
         "--outputjson",

--- a/src/toolguard/buildtime/utils/pytest.py
+++ b/src/toolguard/buildtime/utils/pytest.py
@@ -140,11 +140,27 @@ async def run_tests_in_safe_python_separate_process(
         Result from the test execution process.
     """
 
-    code = f"""
-import pytest
-pytest.main(["{folder / test_file}", "--quiet", "--json-report", "--json-report-file={folder / report_file}"])
-"""
+    code = _build_runner_code(folder, test_file, report_file)
     return await run_safe_python(code, ["pytest"])
+
+
+def _build_runner_code(folder: Path, test_file: Path, report_file: Path) -> str:
+    """Build the pytest-runner snippet executed in the sandboxed interpreter.
+
+    Paths are embedded via ``repr()`` so they survive being executed as source
+    code. ``str(WindowsPath)`` contains backslashes (e.g. ``C:\\Users\\...``);
+    interpolating that raw into a string literal turns ``\\U`` into an invalid
+    unicode escape and the whole snippet fails to compile with
+    ``SyntaxError: ... truncated \\UXXXXXXXX escape``, so pytest never runs and the
+    JSON report is never written. ``repr()`` produces a correctly escaped literal
+    on every platform.
+    """
+    test_path = str(folder / test_file)
+    report_arg = f"--json-report-file={folder / report_file}"
+    return (
+        "\nimport pytest\n"
+        f'pytest.main([{test_path!r}, "--quiet", "--json-report", {report_arg!r}])\n'
+    )
 
 
 def configure(folder: Path):

--- a/tests/buildtime/utils/py/test_top_level_types_encoding.py
+++ b/tests/buildtime/utils/py/test_top_level_types_encoding.py
@@ -1,0 +1,17 @@
+from toolguard.buildtime.utils.py import top_level_types
+
+
+def test_top_level_types_reads_utf8(tmp_path):
+    """Generated files must be parsed as UTF-8, not the platform default.
+
+    Regression: ``Path(path).read_text()`` with no ``encoding`` uses the locale
+    default (cp1252 on a stock Windows launch), which raises
+    ``UnicodeDecodeError: 'charmap' ...`` on non-ASCII content and aborts Generate.
+    """
+    f = tmp_path / "types.py"
+    f.write_text(
+        'NAME = "café — naïve ☃"\n\n\nclass Foo:\n    pass\n',
+        encoding="utf-8",
+    )
+
+    assert top_level_types(f) == {"NAME", "Foo"}

--- a/tests/buildtime/utils/test_pyright_resolve.py
+++ b/tests/buildtime/utils/test_pyright_resolve.py
@@ -1,0 +1,35 @@
+import shutil
+import sys
+
+from toolguard.buildtime.utils.pyright import _resolve_pyright
+
+
+def test_resolve_pyright_returns_non_empty_string():
+    result = _resolve_pyright()
+    assert isinstance(result, str)
+    assert result
+
+
+def test_resolve_pyright_prefers_interpreter_dir(tmp_path, monkeypatch):
+    """The console script next to the interpreter is preferred over PATH.
+
+    Regression: bare ``"pyright"`` raises ``FileNotFoundError [WinError 2]`` when
+    the venv ``Scripts`` dir is not on PATH (common on Windows). Resolving against
+    the interpreter dir fixes it.
+    """
+    fake_python = tmp_path / "python"
+    fake_python.write_text("")
+    (tmp_path / "pyright").write_text("")  # the installed console script
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+
+    assert _resolve_pyright() == str(tmp_path / "pyright")
+
+
+def test_resolve_pyright_falls_back_to_path(tmp_path, monkeypatch):
+    """With no script beside the interpreter, fall back to a PATH lookup."""
+    fake_python = tmp_path / "python"
+    fake_python.write_text("")
+    monkeypatch.setattr(sys, "executable", str(fake_python))
+    monkeypatch.setattr(shutil, "which", lambda name: "/usr/local/bin/pyright")
+
+    assert _resolve_pyright() == "/usr/local/bin/pyright"

--- a/tests/buildtime/utils/test_pytest_runner_code.py
+++ b/tests/buildtime/utils/test_pytest_runner_code.py
@@ -1,0 +1,44 @@
+from pathlib import Path, PureWindowsPath
+
+import pytest
+
+from toolguard.buildtime.utils.pytest import _build_runner_code
+
+
+def test_runner_code_compiles_with_windows_paths():
+    """A Windows work dir must not break the generated pytest snippet.
+
+    Regression: ``str(WindowsPath)`` contains backslashes, and ``C:\\Users``
+    embeds ``\\U`` — an invalid unicode escape. Interpolating it raw into a string
+    literal made the snippet fail to compile (``truncated \\UXXXXXXXX escape``)
+    inside the sandboxed executor, so pytest never ran and the JSON report was
+    never written. ``PureWindowsPath`` reproduces the rendering on any host.
+    """
+    folder = PureWindowsPath(r"C:\Users\bob\proj\Step_2")
+    test_file = PureWindowsPath("tool/test_item.py")
+    report_file = PureWindowsPath("debug/tool/item/guard_0_pytest.json")
+
+    code = _build_runner_code(folder, test_file, report_file)
+
+    # This is exactly what the sandboxed executor does with the snippet.
+    compile(code, "<runner>", "exec")
+
+    # Both paths are present, correctly escaped.
+    assert repr(str(folder / test_file)) in code
+    assert repr(f"--json-report-file={folder / report_file}") in code
+
+
+def test_runner_code_compiles_with_posix_paths():
+    """POSIX paths keep working unchanged."""
+    folder = Path("/tmp/proj/Step_2")
+    code = _build_runner_code(folder, Path("tool/test_item.py"), Path("debug/r.json"))
+    compile(code, "<runner>", "exec")
+
+
+def test_raw_interpolation_would_break_on_windows_paths():
+    """Pins the bug: the previous raw interpolation does not compile for C:\\Users."""
+    folder = PureWindowsPath(r"C:\Users\bob\proj\Step_2")
+    test_file = PureWindowsPath("tool/test_item.py")
+    buggy = f'\nimport pytest\npytest.main(["{folder / test_file}"])\n'
+    with pytest.raises(SyntaxError):
+        compile(buggy, "<runner>", "exec")


### PR DESCRIPTION
## Summary

On Windows the guard **green loop** fails reliably, so `generate_guards_code` silently ships the empty `pass  # FIXME` scaffold instead of a real guard. Three independent failures were each swallowed by a broad `except` and surfaced only as a `WARNING`. This PR fixes all three at the source, plus makes the stub fallback visible.

Surfaced via a downstream Langflow report — langflow-ai/langflow#13727 — where a user reproduced three swallowed failures in sequence, each appearing only after the previous was removed.

## Fixes

### 1. pytest runner — Windows paths broke the executed snippet
`run_tests_in_safe_python_separate_process` built a Python source string by interpolating paths **raw** into a string literal:

```python
pytest.main(["{folder / test_file}", ...])   # folder = C:\Users\...
```

`str(WindowsPath)` uses backslashes, and `C:\Users` contains `\U` — an invalid unicode escape. The snippet failed to compile inside the sandboxed executor (`SyntaxError: ... truncated \UXXXXXXXX escape`), so pytest never ran and the JSON report was never written (which then surfaced as a separate `FileNotFoundError: ...guard_0_pytest.json`). Paths are now embedded via `repr()` (extracted into the testable helper `_build_runner_code`).

### 2. File reads used the platform default encoding
`ast.parse(Path(path).read_text())` (`utils/py.py`) and the bundled prompt loader (`gen_spec/utils.py`) read without `encoding=`. On a stock Windows launch (cp1252) this raises `UnicodeDecodeError: 'charmap' ...` and aborts Generate before it even reaches the green loop. Both now read as UTF-8.

### 3. pyright spawned by bare name → `FileNotFoundError [WinError 2]`
`create_subprocess_exec("pyright", ...)` relies on the venv `Scripts` dir being on `PATH`, which it often isn't on Windows. New `_resolve_pyright()` prefers the console script next to `sys.executable` (handles `pyright` / `.exe` / `.cmd` / `.bat`), then `shutil.which`, then the bare name.

### 4. Stub fallback is no longer invisible
The two terminal fallbacks that return the scaffold guard now log at `error` (with the item name) and state plainly that a no-op stub is being shipped, instead of a `warning` that read like success.

## Tests

New unit tests under `tests/buildtime/utils/` (run on any host — `PureWindowsPath` reproduces the Windows rendering):

- `test_pytest_runner_code.py` — the generated snippet `compile()`s with a `C:\Users\...` work dir, and pins the bug by asserting the old raw interpolation raises `SyntaxError`.
- `test_pyright_resolve.py` — resolver prefers the interpreter dir, falls back to `PATH`.
- `py/test_top_level_types_encoding.py` — non-ASCII source is parsed as UTF-8.

```
tests/buildtime/utils/ + tests/runtime/ : 45 passed
ruff check / ruff format / mypy         : clean
```

No dependency or public-API changes.